### PR TITLE
Fix vruntime accounting and minimum slice

### DIFF
--- a/scheduler.js
+++ b/scheduler.js
@@ -101,7 +101,8 @@ function insertRunningTaskBack(tasks, timeline, callback) {
     // min_vruntime then add it back to the timeline. Since
     // vruntime is greater it won't change min_vruntime when it's
     // added back to the timeline.
-    if (running_task && (running_task.vruntime > min_vruntime) && (running_task.this_slice > running_task.slice)) {
+    if (running_task && (running_task.vruntime > min_vruntime) && (running_task.this_slice > running_task.slice) 
+        && (running_task.this_slice > min_granularity / 1000)) {
         timeline.insert(running_task);
         curTree.insert('n', running_task.vruntime, running_task.id);
         updateMessageDisplay("Inserting " + running_task.id + " with vruntime " + running_task.vruntime);
@@ -144,7 +145,7 @@ function findRunningTask(tasks, timeline, callback) {
     // to null.
     var task_done = false;
     if (running_task) {
-        running_task.vruntime += roundTo(1024/(1000*running_task.slice), 2);
+        running_task.vruntime += roundTo(1024/running_task.weight, 2);
         running_task.truntime++;
         running_task.this_slice++;
         tresults.running_task = running_task;


### PR DESCRIPTION
(a) vruntime should increase by `NICE_0_LOAD / running_task.weight`.
(b) Do not preempt tasks that have not been running for at least `min_granularity` ms.